### PR TITLE
docs(github): Add common GitHub documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+# Bug Report 🐛
+<!--- Provide an expanded summary of the issue -->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+
+## Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context (Environment)
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+### Desktop
+ - OS: [e.g. macOS]
+ - Browser: [e.g. Chrome, Safari]
+ - Version: [e.g. 0.22.15]
+
+## Detailed Description
+<!--- Provide a detailed description of the change or addition you are proposing -->
+
+## Possible Implementation
+<!--- Not obligatory, but suggest an idea for implementing addition or change -->

--- a/.github/ISSUE_TEMPLATE/custom-issue.md
+++ b/.github/ISSUE_TEMPLATE/custom-issue.md
@@ -1,0 +1,18 @@
+---
+name: Custom Issue
+about: For miscellaneous, such as questions, discussions, etc.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+# Discussion 🗣
+<!--- Provide an expanded summary of the issue -->
+
+## Context
+<!--- Providing context helps us come to the discussion informed -->
+
+## Detailed Description
+<!--- Provide any further details -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the feature in the Title above -->
+# Feature Request 🛍️
+<!--- Provide an expanded summary of the feature -->
+
+## Use Case
+<!--- Tell us what feature we should support and what should happen -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest an implementation -->
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Detailed Description
+<!--- Provide a detailed description of the change or addition you are proposing -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+<!--- Provide a formatted commit message describing this PR in the Title above -->
+<!--- See our DEVELOPERS guide below: -->
+<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
+# Closes #<CORRESPONDING ISSUE NUMBER>
+<!--- Provide an overall summary of the pull request -->
+
+### Changes
+<!--- More detailed and granular description of changes -->
+<!--- These should likely be gathered from commit message summaries -->
+- <ONE>
+- <TWO>
+
+### Flags
+<!--- Provide context or concerns a reviewer should be aware of -->
+- <ONE>
+- <TWO>
+
+### Screenshots or Video
+<!--- Provide an easily accessible demonstration of the changes, if applicable -->
+
+### Related Issues
+- Issue #<NUMBER>
+- Pull Request #<NUMBER>
+
+### Author Checklist
+- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
+- [ ] Vital features and changes captured in unit and/or integration tests
+- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
+- [ ] Extend the documentation, if necessary
+- [ ] Merging to `main` from `fork:branchname`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Accord Project Contribution Guide
+
+This repository tracks a [Google Summer of Code Project](https://accordproject.org/news/3-students-accepted-for-google-summer-of-code-2021/), however external contributions are still welcome.
+
+## ❗ Accord Project Contribution Guide ❗
+We'd love for you to contribute to our source code and to make Cicero technology even better than it is today! Please refer to the [Accord Project Contribution guidelines][apcontribute] we'd like you to follow.
+
+## Repository Specific Information
+
+> TODO Add contributing 
+
+[apcontribute]: https://github.com/accordproject/techdocs/blob/master/CONTRIBUTING.md

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,0 +1,16 @@
+# Development Guide
+
+## ❗ Accord Project Development Guide ❗
+We'd love for you to help develop improvements to Cicero technology! Please refer to the [Accord Project Development guidelines][apdev] we'd like you to follow.
+
+## Repository Specific Information
+
+### Development Setup
+
+> TODO
+
+#### Building 
+
+> TODO
+
+[apdev]: https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md

--- a/HEADER
+++ b/HEADER
@@ -1,0 +1,11 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/HEADER.md
+++ b/HEADER.md
@@ -1,0 +1,2 @@
+## License <a name="license"></a>
+Accord Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the LICENSE file. Accord Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0), available at http://creativecommons.org/licenses/by/4.0/.


### PR DESCRIPTION
This PR adds the common GitHub documentation for all Accord Project repositories:
1. Pull Request and Issue Templates
2. License files
3. `.gitignore`, with Python defaults
4. Sample CONTRIBUTING and DEVELOPER documentation